### PR TITLE
fix TypeError: The 'compilation' argument must be an instance of Comp…

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,8 @@
     "msw": "^0.42.0",
     "msw-storybook-addon": "^1.6.3",
     "typescript": "~4.6.2"
+  },
+  "resolutions": {
+    "webpack": "~5.74.0"
   }
 }


### PR DESCRIPTION
…ilation

When running `ng run taskbox:storybook` the folowwing error happens:

```
9% setup compilation SourceMapDevToolPluginC:\src\storybook-intro\taskbox\node_modules\webpack\lib\javascript\JavascriptModulesPlugin.js:143
                        throw new TypeError(
                              ^

TypeError: The 'compilation' argument must be an instance of Compilation
    at Function.getCompilationHooks (C:\src\storybook-intro\taskbox\node_modules\webpack\lib\javascript\JavascriptModulesPlugin.js:143:10)
```